### PR TITLE
Remove internal from constructor and update Dappfile

### DIFF
--- a/Dappfile
+++ b/Dappfile
@@ -2,9 +2,9 @@ name: token-wrapper
 version: 0.0.1-dev
 tags: []
 layout:
-  sol_sources: src
-  build_dir: build
-  packages_directory: .dapple/packages/
+  sol_sources: ./src
+  build_dir: ./build
+  packages_directory: ./.dapple/packages/
 dependencies: {}
 ignore:
   - gnt_test.t.sol
@@ -12,27 +12,32 @@ environments:
   develop:
     objects: {}
     type: internal
+    chain: ''
   festfork:
     objects:
       gnt:
         type: GolemNetworkToken
         value: '0xa74476443119A942dE498590Fe1f2454d7D4aC0d'
     type: UNKNOWN
+    chain: ''
   testfork:
     objects:
       gnt:
         type: GolemNetworkToken
         value: '0xa74476443119A942dE498590Fe1f2454d7D4aC0d'
     type: UNKNOWN
+    chain: ''
   localtest:
     objects: {}
     type: UNKNOWN
+    chain: ''
   morden:
     objects:
       gnt:
         type: GolemNetworkToken
         value: '0x9d6bb976159a6c131512ce27c83ba1fcb05b22ea'
     type: MORDEN
+    chain: ''
   ropsten:
     objects:
       gnt:
@@ -43,12 +48,14 @@ environments:
         type: >-
           TokenWrapper[74e33d3d8845c25656659612e0989064a5ac9732b29bdd6f942dc662407827bd]
     type: ropsten
+    chain: ''
   IntegTests:
     objects:
       gnt:
         type: GolemNetworkToken
         value: '0xa74476443119A942dE498590Fe1f2454d7D4aC0d'
     type: internal
+    chain: ''
   live:
     objects:
       gnt:
@@ -59,4 +66,9 @@ environments:
         type: >-
           TokenWrapper[b10b907625d773ba71be6676c46c412e3736d4bb27ec4f9f0f45a52d7fa3685c]
     type: ETH
-dapple_version: 0.8.36
+dapple_version: 0.8.47
+description: ''
+authors: []
+license: Apache-2.0
+keywords:
+  - dapple

--- a/src/golem_source.sol
+++ b/src/golem_source.sol
@@ -232,7 +232,7 @@ contract GNTAllocation {
 
     uint256 tokensCreated = 0;
 
-    function GNTAllocation(address _golemFactory) internal {
+    function GNTAllocation(address _golemFactory) {
         gnt = GolemNetworkToken(msg.sender);
         unlockedAt = now + 6 * 30 days;
 


### PR DESCRIPTION
Starting with `solc 0.4.9` this fails to compile. Tested with `solc 0.4.10 commit 6bba106` and it still fails.

I think this is a safe change.